### PR TITLE
Upgrade to roblox_install 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,11 +1734,12 @@ dependencies = [
 
 [[package]]
 name = "roblox_install"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d8c86f81b83db9b127bf66b51b9a24c844fe755f43310e56c09e2303148527"
+checksum = "743bb8c693a387f1ae8d2026d82d8b0c175cc4777b97c1f7b12fdb3be595bb13"
 dependencies = [
  "dirs 2.0.2",
+ "thiserror",
  "winreg 0.6.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ path-slash = "0.1.3"
 png = "0.15.3"
 regex = "1.3.3"
 reqwest = "0.9.24"
-roblox_install = "0.3.0"
+roblox_install = "1.0.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 structopt = { version = "0.3", default-features = false }


### PR DESCRIPTION
1.0.0 includes the ability to set the Studio installation path through an environment variable which is useful for people who use WSL, like myself.