### PR TITLE
Fix x-csrf-token

### DIFF
--- a/src/auth_cookie.rs
+++ b/src/auth_cookie.rs
@@ -15,7 +15,7 @@ pub fn get_auth_cookie() -> Option<SecretString> {
 
 pub fn get_csrf_token(roblosecurity_cookie: &SecretString) -> Result<HeaderValue, RobloxApiError> {
     let response = Client::new()
-        .post("https://auth.roblox.com")
+        .post("https://auth.roblox.com/v2/login")
         .header(header::COOKIE, roblosecurity_cookie.expose_secret())
         .header(header::CONTENT_LENGTH, 0)
         .send();


### PR DESCRIPTION
This PR is a simple fix which changes the endpoint used for the `x-csrf-token`.

Also worth mentioning that you cannot build tarmac in debug mode for reasons outlined [here.](https://stackoverflow.com/questions/78504296/rust-project-is-suddenly-failing-on-windows-slicefrom-raw-parts-requires-the)